### PR TITLE
Update UnitTestGenerator.py

### DIFF
--- a/coverage_ai/CoverageAi.py
+++ b/coverage_ai/CoverageAi.py
@@ -94,6 +94,14 @@ class CoverageAi:
             else:
                 self.logger.info(failure_message)
 
+        # Provide metric on total token usage
+        self.logger.info(
+            f"Total number of input tokens used for LLM model {self.test_gen.ai_caller.model}: {self.test_gen.total_input_token_count}"
+        )
+        self.logger.info(
+            f"Total number of output tokens used for LLM model {self.test_gen.ai_caller.model}: {self.test_gen.total_output_token_count}"
+        )
+
         ReportGenerator.generate_report(test_results_list, self.args.report_filepath)
 
         if "WANDB_API_KEY" in os.environ:

--- a/coverage_ai/PromptBuilder.py
+++ b/coverage_ai/PromptBuilder.py
@@ -98,7 +98,8 @@ class PromptBuilder:
             else ""
         )
 
-    def _read_file(self, file_path):
+    @staticmethod
+    def _read_file(file_path):
         """
         Helper method to read file contents.
 

--- a/coverage_ai/UnitTestGenerator.py
+++ b/coverage_ai/UnitTestGenerator.py
@@ -70,6 +70,8 @@ class UnitTestGenerator:
         # States to maintain within this class
         self.preprocessor = FilePreprocessor(self.test_file_path)
         self.failed_test_runs = []
+        self.total_input_token_count = 0
+        self.total_output_token_count = 0
 
         # Run coverage and build the prompt
         self.run_coverage()
@@ -127,10 +129,10 @@ class UnitTestGenerator:
         stdout, stderr, exit_code, time_of_test_command = Runner.run_command(
             command=self.test_command, cwd=self.test_command_dir
         )
-        if (
-            exit_code != 0
-        ):
-            raise AssertionError(f'Fatal: Error running test command. Are you sure the command is correct? "{self.test_command}"\nExit code {exit_code}. \nStdout: \n{stdout} \nStderr: \n{stderr}')
+        assert (
+            exit_code == 0
+        ), f'Fatal: Error running test command. Are you sure the command is correct? "{self.test_command}"\nExit code {exit_code}. \nStdout: \n{stdout} \nStderr: \n{stderr}'
+
         # Instantiate CoverageProcessor and process the coverage report
         coverage_processor = CoverageProcessor(
             file_path=self.code_coverage_report_path,
@@ -249,6 +251,21 @@ class UnitTestGenerator:
         return self.prompt_builder.build_prompt()
 
     def initial_test_suite_analysis(self):
+        """
+        Perform the initial analysis of the test suite structure.
+
+        This method iterates through a series of attempts to analyze the test suite structure by interacting with the AI model.
+        It constructs prompts based on specific files and calls to the AI model to gather information such as test headers indentation,
+        relevant line numbers for inserting new tests, and relevant line numbers for inserting imports.
+        The method handles multiple attempts to gather this information and raises exceptions if the analysis fails.
+
+        Raises:
+            Exception: If the test headers indentation cannot be analyzed successfully.
+            Exception: If the relevant line number to insert new tests cannot be determined.
+
+        Returns:
+            None
+        """
         try:
             test_headers_indentation = None
             allowed_attempts = 3
@@ -262,6 +279,8 @@ class UnitTestGenerator:
                 response, prompt_token_count, response_token_count = (
                     self.ai_caller.call_model(prompt=prompt_headers_indentation)
                 )
+                self.total_input_token_count += prompt_token_count
+                self.total_output_token_count += response_token_count
                 tests_dict = load_yaml(response)
                 test_headers_indentation = tests_dict.get(
                     "test_headers_indentation", None
@@ -285,6 +304,8 @@ class UnitTestGenerator:
                 response, prompt_token_count, response_token_count = (
                     self.ai_caller.call_model(prompt=prompt_test_insert_line)
                 )
+                self.total_input_token_count += prompt_token_count
+                self.total_output_token_count += response_token_count
                 tests_dict = load_yaml(response)
                 relevant_line_number_to_insert_tests_after = tests_dict.get(
                     "relevant_line_number_to_insert_tests_after", None
@@ -311,6 +332,24 @@ class UnitTestGenerator:
             raise Exception("Error during initial test suite analysis")
 
     def generate_tests(self, max_tokens=4096, dry_run=False):
+        """
+        Generate tests using the AI model based on the constructed prompt.
+
+        This method generates tests by calling the AI model with the constructed prompt.
+        It handles both dry run and actual test generation scenarios. In a dry run, it returns canned test responses.
+        In the actual run, it calls the AI model with the prompt and processes the response to extract test
+        information such as test tags, test code, test name, and test behavior.
+
+        Parameters:
+            max_tokens (int, optional): The maximum number of tokens to use for generating tests. Defaults to 4096.
+            dry_run (bool, optional): A flag indicating whether to perform a dry run without calling the AI model. Defaults to False.
+
+        Returns:
+            dict: A dictionary containing the generated tests with test tags, test code, test name, and test behavior. If an error occurs during test generation, an empty dictionary is returned.
+
+        Raises:
+            Exception: If there is an error during test generation, such as a parsing error while processing the AI model response.
+        """
         self.prompt = self.build_prompt()
 
         if dry_run:
@@ -319,9 +358,8 @@ class UnitTestGenerator:
             response, prompt_token_count, response_token_count = (
                 self.ai_caller.call_model(prompt=self.prompt, max_tokens=max_tokens)
             )
-        self.logger.info(
-            f"Total token used count for LLM model {self.ai_caller.model}: {prompt_token_count + response_token_count}"
-        )
+            self.total_input_token_count += prompt_token_count
+            self.total_output_token_count += response_token_count
         try:
             tests_dict = load_yaml(
                 response,
@@ -346,6 +384,32 @@ class UnitTestGenerator:
         return tests_dict
 
     def validate_test(self, generated_test: dict, generated_tests_dict: dict):
+        """
+        Validate a generated test by inserting it into the test file, running the test, and checking for pass/fail.
+
+        Parameters:
+            generated_test (dict): The generated test to validate, containing test code and additional imports.
+            generated_tests_dict (dict): A dictionary containing information about the generated tests.
+
+        Returns:
+            dict: A dictionary containing the status of the test validation, including pass/fail status, exit code, stderr, stdout, and the test details.
+
+        Steps:
+            0. Assume each generated test is a self-contained independent test.
+            1. Extract the test code and additional imports from the generated test.
+            2. Clean up the additional imports if necessary.
+            3. Determine the relevant line numbers for inserting tests and imports.
+            4. Adjust the indentation of the test code to match the required indentation.
+            5. Insert the test code and additional imports into the test file at the relevant lines.
+            6. Run the test using the Runner class.
+            7. Check the exit code to determine if the test passed or failed.
+            8. If the test failed, roll back the test file to its original content and log the failure.
+            9. If the test passed, check if the code coverage has increased using the CoverageProcessor class.
+            10. If the coverage has not increased, roll back the test file and log the failure.
+            11. If the coverage has increased, update the current coverage and log the success.
+            12. Handle any exceptions that occur during the validation process, log the errors, and roll back the test file if necessary.
+            13. Log additional details and error messages for failed tests, and optionally, use the Trace class for detailed logging if 'WANDB_API_KEY' is present in the environment variables.
+        """
         try:
             # Step 0: no pre-process.
             # We asked the model that each generated test should be a self-contained independent test
@@ -559,6 +623,16 @@ class UnitTestGenerator:
 
 
 def extract_error_message_python(fail_message):
+    """
+    Extracts and returns the error message from the provided failure message.
+
+    Parameters:
+        fail_message (str): The failure message containing the error message to be extracted.
+
+    Returns:
+        str: The extracted error message from the failure message, or an empty string if no error message is found.
+
+    """
     try:
         # Define a regular expression pattern to match the error message
         MAX_LINES = 20

--- a/coverage_ai/UnitTestGenerator.py
+++ b/coverage_ai/UnitTestGenerator.py
@@ -70,14 +70,13 @@ class UnitTestGenerator:
         # States to maintain within this class
         self.preprocessor = FilePreprocessor(self.test_file_path)
         self.failed_test_runs = []
-        self.total_input_token_count = 0
-        self.total_output_token_count = 0
 
         # Run coverage and build the prompt
         self.run_coverage()
         self.prompt = self.build_prompt()
 
-    def get_code_language(self, source_file_path):
+    @staticmethod
+    def get_code_language(source_file_path):
         """
         Get the programming language based on the file extension of the provided source file path.
 
@@ -129,10 +128,10 @@ class UnitTestGenerator:
         stdout, stderr, exit_code, time_of_test_command = Runner.run_command(
             command=self.test_command, cwd=self.test_command_dir
         )
-        assert (
-            exit_code == 0
-        ), f'Fatal: Error running test command. Are you sure the command is correct? "{self.test_command}"\nExit code {exit_code}. \nStdout: \n{stdout} \nStderr: \n{stderr}'
-
+        if (
+            exit_code != 0
+        ):
+            raise AssertionError(f'Fatal: Error running test command. Are you sure the command is correct? "{self.test_command}"\nExit code {exit_code}. \nStdout: \n{stdout} \nStderr: \n{stderr}')
         # Instantiate CoverageProcessor and process the coverage report
         coverage_processor = CoverageProcessor(
             file_path=self.code_coverage_report_path,
@@ -251,21 +250,6 @@ class UnitTestGenerator:
         return self.prompt_builder.build_prompt()
 
     def initial_test_suite_analysis(self):
-        """
-        Perform the initial analysis of the test suite structure.
-
-        This method iterates through a series of attempts to analyze the test suite structure by interacting with the AI model.
-        It constructs prompts based on specific files and calls to the AI model to gather information such as test headers indentation,
-        relevant line numbers for inserting new tests, and relevant line numbers for inserting imports.
-        The method handles multiple attempts to gather this information and raises exceptions if the analysis fails.
-
-        Raises:
-            Exception: If the test headers indentation cannot be analyzed successfully.
-            Exception: If the relevant line number to insert new tests cannot be determined.
-
-        Returns:
-            None
-        """
         try:
             test_headers_indentation = None
             allowed_attempts = 3
@@ -279,8 +263,6 @@ class UnitTestGenerator:
                 response, prompt_token_count, response_token_count = (
                     self.ai_caller.call_model(prompt=prompt_headers_indentation)
                 )
-                self.total_input_token_count += prompt_token_count
-                self.total_output_token_count += response_token_count
                 tests_dict = load_yaml(response)
                 test_headers_indentation = tests_dict.get(
                     "test_headers_indentation", None
@@ -304,8 +286,6 @@ class UnitTestGenerator:
                 response, prompt_token_count, response_token_count = (
                     self.ai_caller.call_model(prompt=prompt_test_insert_line)
                 )
-                self.total_input_token_count += prompt_token_count
-                self.total_output_token_count += response_token_count
                 tests_dict = load_yaml(response)
                 relevant_line_number_to_insert_tests_after = tests_dict.get(
                     "relevant_line_number_to_insert_tests_after", None
@@ -332,24 +312,6 @@ class UnitTestGenerator:
             raise Exception("Error during initial test suite analysis")
 
     def generate_tests(self, max_tokens=4096, dry_run=False):
-        """
-        Generate tests using the AI model based on the constructed prompt.
-
-        This method generates tests by calling the AI model with the constructed prompt.
-        It handles both dry run and actual test generation scenarios. In a dry run, it returns canned test responses.
-        In the actual run, it calls the AI model with the prompt and processes the response to extract test
-        information such as test tags, test code, test name, and test behavior.
-
-        Parameters:
-            max_tokens (int, optional): The maximum number of tokens to use for generating tests. Defaults to 4096.
-            dry_run (bool, optional): A flag indicating whether to perform a dry run without calling the AI model. Defaults to False.
-
-        Returns:
-            dict: A dictionary containing the generated tests with test tags, test code, test name, and test behavior. If an error occurs during test generation, an empty dictionary is returned.
-
-        Raises:
-            Exception: If there is an error during test generation, such as a parsing error while processing the AI model response.
-        """
         self.prompt = self.build_prompt()
 
         if dry_run:
@@ -358,8 +320,9 @@ class UnitTestGenerator:
             response, prompt_token_count, response_token_count = (
                 self.ai_caller.call_model(prompt=self.prompt, max_tokens=max_tokens)
             )
-            self.total_input_token_count += prompt_token_count
-            self.total_output_token_count += response_token_count
+        self.logger.info(
+            f"Total token used count for LLM model {self.ai_caller.model}: {prompt_token_count + response_token_count}"
+        )
         try:
             tests_dict = load_yaml(
                 response,
@@ -384,32 +347,6 @@ class UnitTestGenerator:
         return tests_dict
 
     def validate_test(self, generated_test: dict, generated_tests_dict: dict):
-        """
-        Validate a generated test by inserting it into the test file, running the test, and checking for pass/fail.
-
-        Parameters:
-            generated_test (dict): The generated test to validate, containing test code and additional imports.
-            generated_tests_dict (dict): A dictionary containing information about the generated tests.
-
-        Returns:
-            dict: A dictionary containing the status of the test validation, including pass/fail status, exit code, stderr, stdout, and the test details.
-
-        Steps:
-            0. Assume each generated test is a self-contained independent test.
-            1. Extract the test code and additional imports from the generated test.
-            2. Clean up the additional imports if necessary.
-            3. Determine the relevant line numbers for inserting tests and imports.
-            4. Adjust the indentation of the test code to match the required indentation.
-            5. Insert the test code and additional imports into the test file at the relevant lines.
-            6. Run the test using the Runner class.
-            7. Check the exit code to determine if the test passed or failed.
-            8. If the test failed, roll back the test file to its original content and log the failure.
-            9. If the test passed, check if the code coverage has increased using the CoverageProcessor class.
-            10. If the coverage has not increased, roll back the test file and log the failure.
-            11. If the coverage has increased, update the current coverage and log the success.
-            12. Handle any exceptions that occur during the validation process, log the errors, and roll back the test file if necessary.
-            13. Log additional details and error messages for failed tests, and optionally, use the Trace class for detailed logging if 'WANDB_API_KEY' is present in the environment variables.
-        """
         try:
             # Step 0: no pre-process.
             # We asked the model that each generated test should be a self-contained independent test
@@ -623,16 +560,6 @@ class UnitTestGenerator:
 
 
 def extract_error_message_python(fail_message):
-    """
-    Extracts and returns the error message from the provided failure message.
-
-    Parameters:
-        fail_message (str): The failure message containing the error message to be extracted.
-
-    Returns:
-        str: The extracted error message from the failure message, or an empty string if no error message is found.
-
-    """
     try:
         # Define a regular expression pattern to match the error message
         MAX_LINES = 20

--- a/coverage_ai/utils.py
+++ b/coverage_ai/utils.py
@@ -5,7 +5,7 @@ import yaml
 from typing import List
 
 
-def load_yaml(response_text: str, keys_fix_yaml: List[str] = []) -> dict:
+def load_yaml(response_text: str, keys_fix_yaml: List[str] = None) -> dict:
     """
     Load and parse YAML data from a given response text.
 
@@ -22,6 +22,8 @@ def load_yaml(response_text: str, keys_fix_yaml: List[str] = []) -> dict:
         load_yaml(response_text, keys_fix_yaml=['key1', 'key2'])
 
     """
+    if keys_fix_yaml is None:
+        keys_fix_yaml = []
     response_text = response_text.strip().removeprefix("```yaml").rstrip("`")
     try:
         data = yaml.safe_load(response_text)
@@ -35,7 +37,7 @@ def load_yaml(response_text: str, keys_fix_yaml: List[str] = []) -> dict:
     return data
 
 
-def try_fix_yaml(response_text: str, keys_fix_yaml: List[str] = []) -> dict:
+def try_fix_yaml(response_text: str, keys_fix_yaml: List[str] = None) -> dict:
     """
     Attempt to fix YAML formatting issues in the given response text.
 
@@ -57,6 +59,8 @@ def try_fix_yaml(response_text: str, keys_fix_yaml: List[str] = []) -> dict:
     Example:
         try_fix_yaml(response_text, keys_fix_yaml=['key1', 'key2'])
     """
+    if keys_fix_yaml is None:
+        keys_fix_yaml = []
     response_text_lines = response_text.split("\n")
 
     # first fallback - try to convert 'relevant line: ...' to relevant line: |-\n        ...'

--- a/tests/test_AICaller.py
+++ b/tests/test_AICaller.py
@@ -104,7 +104,8 @@ class TestAICaller:
             assert prompt_tokens == 2
             assert response_tokens == 10
 
-    def test_call_model_missing_keys(self, ai_caller):
+    @staticmethod
+    def test_call_model_missing_keys(ai_caller):
         prompt = {"user": "Hello, world!"}
         with pytest.raises(KeyError) as exc_info:
             ai_caller.call_model(prompt)

--- a/tests/test_CoverageAi.py
+++ b/tests/test_CoverageAi.py
@@ -7,7 +7,8 @@ from coverage_ai.main import parse_args
 
 
 class TestCoverageAi:
-    def test_parse_args(self):
+    @staticmethod
+    def test_parse_args():
         with patch(
             "sys.argv",
             [

--- a/tests/test_CoverageAi.py
+++ b/tests/test_CoverageAi.py
@@ -58,9 +58,8 @@ class TestCoverageAi:
         parse_args = lambda: args
         mock_isfile.return_value = False
 
-        with patch("coverage_ai.main.parse_args", parse_args):
-            with pytest.raises(FileNotFoundError) as exc_info:
-                agent = CoverageAi(args)
+        with patch("coverage_ai.main.parse_args", parse_args), pytest.raises(FileNotFoundError) as exc_info:
+            agent = CoverageAi(args)
 
         assert (
             str(exc_info.value) == f"Source file not found at {args.source_file_path}"
@@ -92,8 +91,7 @@ class TestCoverageAi:
         mock_isfile.side_effect = [True, False]
         mock_exists.return_value = True
 
-        with patch("coverage_ai.main.parse_args", parse_args):
-            with pytest.raises(FileNotFoundError) as exc_info:
-                agent = CoverageAi(args)
+        with patch("coverage_ai.main.parse_args", parse_args), pytest.raises(FileNotFoundError) as exc_info:
+            agent = CoverageAi(args)
 
         assert str(exc_info.value) == f"Test file not found at {args.test_file_path}"

--- a/tests/test_CoverageProcessor.py
+++ b/tests/test_CoverageProcessor.py
@@ -37,7 +37,8 @@ class TestCoverageProcessor:
         # Initializes CoverageProcessor with cobertura coverage type for each test
         return CoverageProcessor("fake_path", "app.py", "cobertura")
 
-    def test_parse_coverage_report_cobertura(self, mock_xml_tree, processor):
+    @staticmethod
+    def test_parse_coverage_report_cobertura(mock_xml_tree, processor):
         """
         Tests the parse_coverage_report method for correct line number and coverage calculation with Cobertura reports.
         """
@@ -47,7 +48,8 @@ class TestCoverageProcessor:
         assert missed_lines == [2], "Should list line 2 as missed"
         assert coverage_pct == 0.5, "Coverage should be 50 percent"
 
-    def test_correct_parsing_for_matching_package_and_class(self, mocker):
+    @staticmethod
+    def test_correct_parsing_for_matching_package_and_class(mocker):
         # Setup
         mock_open = mocker.patch(
             "builtins.open",
@@ -79,7 +81,8 @@ class TestCoverageProcessor:
         assert missed == 5
         assert covered == 10
 
-    def test_returns_empty_lists_and_float(self, mocker):
+    @staticmethod
+    def test_returns_empty_lists_and_float(mocker):
         # Mocking the necessary methods
         mocker.patch(
             "coverage_ai.CoverageProcessor.CoverageProcessor.extract_package_and_class_java",
@@ -107,20 +110,23 @@ class TestCoverageProcessor:
         assert lines_missed == [], "Expected lines_missed to be an empty list"
         assert coverage_percentage == 0, "Expected coverage percentage to be 0"
 
-    def test_parse_coverage_report_unsupported_type(self):
+    @staticmethod
+    def test_parse_coverage_report_unsupported_type():
         processor = CoverageProcessor("fake_path", "app.py", "unsupported_type")
         with pytest.raises(
             ValueError, match="Unsupported coverage report type: unsupported_type"
         ):
             processor.parse_coverage_report()
 
-    def test_extract_package_and_class_java_file_error(self, mocker):
+    @staticmethod
+    def test_extract_package_and_class_java_file_error(mocker):
         mocker.patch("builtins.open", side_effect=FileNotFoundError("File not found"))
         processor = CoverageProcessor("fake_path", "path/to/MyClass.java", "jacoco")
         with pytest.raises(FileNotFoundError, match="File not found"):
             processor.extract_package_and_class_java()
 
-    def test_extract_package_and_class_java(self, mocker):
+    @staticmethod
+    def test_extract_package_and_class_java(mocker):
         java_file_content = """
         package com.example;
     
@@ -136,7 +142,8 @@ class TestCoverageProcessor:
         ), "Expected package name to be 'com.example'"
         assert class_name == "MyClass", "Expected class name to be 'MyClass'"
 
-    def test_verify_report_update_file_not_updated(self, mocker):
+    @staticmethod
+    def test_verify_report_update_file_not_updated(mocker):
         mocker.patch("os.path.exists", return_value=True)
         mocker.patch("os.path.getmtime", return_value=1234567.0)
 
@@ -147,7 +154,8 @@ class TestCoverageProcessor:
         ):
             processor.verify_report_update(1234567890)
 
-    def test_verify_report_update_file_not_exist(self, mocker):
+    @staticmethod
+    def test_verify_report_update_file_not_exist(mocker):
         mocker.patch("os.path.exists", return_value=False)
 
         processor = CoverageProcessor("fake_path", "app.py", "cobertura")
@@ -157,7 +165,8 @@ class TestCoverageProcessor:
         ):
             processor.verify_report_update(1234567890)
 
-    def test_process_coverage_report(self, mocker):
+    @staticmethod
+    def test_process_coverage_report(mocker):
         mock_verify = mocker.patch(
             "coverage_ai.CoverageProcessor.CoverageProcessor.verify_report_update"
         )
@@ -173,7 +182,8 @@ class TestCoverageProcessor:
         mock_parse.assert_called_once()
         assert result == ([], [], 0.0), "Expected result to be ([], [], 0.0)"
 
-    def test_parse_missed_covered_lines_jacoco_key_error(self, mocker):
+    @staticmethod
+    def test_parse_missed_covered_lines_jacoco_key_error(mocker):
         mock_open = mocker.patch(
             "builtins.open",
             mocker.mock_open(
@@ -194,7 +204,8 @@ class TestCoverageProcessor:
         with pytest.raises(KeyError):
             processor.parse_missed_covered_lines_jacoco("com.example", "MyClass")
 
-    def test_parse_coverage_report_lcov_no_coverage_data(self, mocker):
+    @staticmethod
+    def test_parse_coverage_report_lcov_no_coverage_data(mocker):
         """
         Test parse_coverage_report_lcov returns empty lists and 0 coverage when the lcov report contains no relevant data.
         """
@@ -205,7 +216,8 @@ class TestCoverageProcessor:
         assert missed_lines == [], "Expected no missed lines"
         assert coverage_pct == 0, "Expected 0% coverage"
 
-    def test_parse_coverage_report_lcov_with_coverage_data(self, mocker):
+    @staticmethod
+    def test_parse_coverage_report_lcov_with_coverage_data(mocker):
         """
         Test parse_coverage_report_lcov correctly parses coverage data from an lcov report.
         """
@@ -223,7 +235,8 @@ class TestCoverageProcessor:
         assert missed_lines == [2], "Expected line 2 to be missed"
         assert coverage_pct == 2/3, "Expected 66.67% coverage"
 
-    def test_parse_coverage_report_lcov_with_multiple_files(self, mocker):
+    @staticmethod
+    def test_parse_coverage_report_lcov_with_multiple_files(mocker):
         """
         Test parse_coverage_report_lcov correctly parses coverage data for the target file among multiple files in the lcov report.
         """

--- a/tests/test_FilePreprocessor.py
+++ b/tests/test_FilePreprocessor.py
@@ -5,7 +5,8 @@ from coverage_ai.FilePreprocessor import FilePreprocessor
 
 class TestFilePreprocessor:
     # Test for a C file
-    def test_c_file(self):
+    @staticmethod
+    def test_c_file():
         with tempfile.NamedTemporaryFile(delete=False, suffix=".c") as tmp:
             preprocessor = FilePreprocessor(tmp.name)
             input_text = "Lorem ipsum dolor sit amet,\nconsectetur adipiscing elit,\nsed do eiusmod tempor incididunt."
@@ -15,7 +16,8 @@ class TestFilePreprocessor:
             ), "C file processing should not alter the text."
 
     # Test for a Python file with only a function
-    def test_py_file_with_function_only(self):
+    @staticmethod
+    def test_py_file_with_function_only():
         with tempfile.NamedTemporaryFile(delete=False, suffix=".py") as tmp:
             tmp.write(b"def function():\n    pass\n")
             tmp.close()
@@ -27,7 +29,8 @@ class TestFilePreprocessor:
             ), "Python file without class should not alter the text."
 
     # Test for a Python file with a comment that looks like a class definition
-    def test_py_file_with_commented_class(self):
+    @staticmethod
+    def test_py_file_with_commented_class():
         with tempfile.NamedTemporaryFile(delete=False, suffix=".py") as tmp:
             tmp.write(b"# class myPythonFile:\n#    pass\n")
             tmp.close()
@@ -39,7 +42,8 @@ class TestFilePreprocessor:
             ), "Commented class definition should not trigger processing."
 
     # Test for a Python file with an actual class definition
-    def test_py_file_with_class(self):
+    @staticmethod
+    def test_py_file_with_class():
         with tempfile.NamedTemporaryFile(delete=False, suffix=".py") as tmp:
             tmp.write(b"class MyClass:\n    def method(self):\n        pass\n")
             tmp.close()
@@ -51,7 +55,8 @@ class TestFilePreprocessor:
                 processed_text == expected_output
             ), "Python file with class should indent the text."
 
-    def test_py_file_with_syntax_error(self):
+    @staticmethod
+    def test_py_file_with_syntax_error():
         with tempfile.NamedTemporaryFile(delete=False, suffix=".py") as tmp:
             tmp.write(b"def function(:\n    pass\n")  # Invalid syntax
             tmp.close()

--- a/tests/test_PromptBuilder.py
+++ b/tests/test_PromptBuilder.py
@@ -10,7 +10,8 @@ class TestPromptBuilder:
         monkeypatch.setattr("builtins.open", mock_open_obj)
         self.mock_open_obj = mock_open_obj
 
-    def test_initialization_reads_file_contents(self):
+    @staticmethod
+    def test_initialization_reads_file_contents():
         builder = PromptBuilder(
             "source_path",
             "test_path",
@@ -21,7 +22,8 @@ class TestPromptBuilder:
         assert builder.code_coverage_report == "dummy content"
         assert builder.included_files == ""  # Updated expected value
 
-    def test_initialization_handles_file_read_errors(self, monkeypatch):
+    @staticmethod
+    def test_initialization_handles_file_read_errors(monkeypatch):
         def mock_open_raise(*args, **kwargs):
             raise IOError("File not found")
 
@@ -35,7 +37,8 @@ class TestPromptBuilder:
         assert "Error reading source_path" in builder.source_file
         assert "Error reading test_path" in builder.test_file
 
-    def test_empty_included_files_section_not_in_prompt(self, monkeypatch):
+    @staticmethod
+    def test_empty_included_files_section_not_in_prompt(monkeypatch):
         # Disable the monkeypatch for open within this test
         monkeypatch.undo()
         builder = PromptBuilder(
@@ -53,7 +56,8 @@ class TestPromptBuilder:
         result = builder.build_prompt()
         assert "## Additional Includes" not in result["user"]
 
-    def test_non_empty_included_files_section_in_prompt(self, monkeypatch):
+    @staticmethod
+    def test_non_empty_included_files_section_in_prompt(monkeypatch):
         # Disable the monkeypatch for open within this test
         monkeypatch.undo()
         builder = PromptBuilder(
@@ -71,7 +75,8 @@ class TestPromptBuilder:
         assert "## Additional Includes" in result["user"]
         assert "Included Files Content" in result["user"]
 
-    def test_empty_additional_instructions_section_not_in_prompt(self, monkeypatch):
+    @staticmethod
+    def test_empty_additional_instructions_section_not_in_prompt(monkeypatch):
         # Disable the monkeypatch for open within this test
         monkeypatch.undo()
         builder = PromptBuilder(
@@ -87,7 +92,8 @@ class TestPromptBuilder:
         result = builder.build_prompt()
         assert "## Additional Instructions" not in result["user"]
 
-    def test_empty_failed_test_runs_section_not_in_prompt(self, monkeypatch):
+    @staticmethod
+    def test_empty_failed_test_runs_section_not_in_prompt(monkeypatch):
         # Disable the monkeypatch for open within this test
         monkeypatch.undo()
         builder = PromptBuilder(
@@ -103,7 +109,8 @@ class TestPromptBuilder:
         result = builder.build_prompt()
         assert "## Previous Iterations Failed Tests" not in result["user"]
 
-    def test_non_empty_additional_instructions_section_in_prompt(self, monkeypatch):
+    @staticmethod
+    def test_non_empty_additional_instructions_section_in_prompt(monkeypatch):
         # Disable the monkeypatch for open within this test
         monkeypatch.undo()
         builder = PromptBuilder(
@@ -121,7 +128,8 @@ class TestPromptBuilder:
         assert "Additional Instructions Content" in result["user"]
 
     # we currently disabled the logic to add failed test runs to the prompt
-    def test_non_empty_failed_test_runs_section_in_prompt(self, monkeypatch):
+    @staticmethod
+    def test_non_empty_failed_test_runs_section_in_prompt(monkeypatch):
         # Disable the monkeypatch for open within this test
         monkeypatch.undo()
         builder = PromptBuilder(
@@ -139,7 +147,8 @@ class TestPromptBuilder:
         assert "## Previous Iterations Failed Tests" in result["user"]
         assert "Failed Test Runs Content" in result["user"]
 
-    def test_build_prompt_custom_handles_rendering_exception(self, monkeypatch):
+    @staticmethod
+    def test_build_prompt_custom_handles_rendering_exception(monkeypatch):
         def mock_render(*args, **kwargs):
             raise Exception("Rendering error")
 
@@ -156,7 +165,8 @@ class TestPromptBuilder:
         result = builder.build_prompt_custom("custom_file")
         assert result == {"system": "", "user": ""}
 
-    def test_build_prompt_handles_rendering_exception(self, monkeypatch):
+    @staticmethod
+    def test_build_prompt_handles_rendering_exception(monkeypatch):
         def mock_render(*args, **kwargs):
             raise Exception("Rendering error")
 

--- a/tests/test_ReportGenerator.py
+++ b/tests/test_ReportGenerator.py
@@ -30,7 +30,8 @@ class TestReportGeneration:
         expected_end = "</html>"
         return expected_start, expected_table_header, expected_row_content, expected_end
 
-    def test_generate_report(self, sample_results, expected_output, tmp_path):
+    @staticmethod
+    def test_generate_report(sample_results, expected_output, tmp_path):
         report_path = tmp_path / "test_report.html"
         ReportGenerator.generate_report(sample_results, str(report_path))
 

--- a/tests/test_Runner.py
+++ b/tests/test_Runner.py
@@ -2,7 +2,8 @@ from coverage_ai.Runner import Runner  # Adjust the import path as necessary
 
 
 class TestRunner:
-    def test_run_command_success(self):
+    @staticmethod
+    def test_run_command_success():
         """Test the run_command method with a command that succeeds."""
         command = 'echo "Hello, World!"'
         stdout, stderr, exit_code, _ = Runner.run_command(command)
@@ -10,7 +11,8 @@ class TestRunner:
         assert stderr == ""
         assert exit_code == 0
 
-    def test_run_command_with_cwd(self):
+    @staticmethod
+    def test_run_command_with_cwd():
         """Test the run_command method with a specified working directory."""
         command = 'echo "Working Directory"'
         stdout, stderr, exit_code, _ = Runner.run_command(command, cwd="/tmp")
@@ -18,7 +20,8 @@ class TestRunner:
         assert stderr == ""
         assert exit_code == 0
 
-    def test_run_command_failure(self):
+    @staticmethod
+    def test_run_command_failure():
         """Test the run_command method with a command that fails."""
         # Use a command that is guaranteed to fail
         command = "command_that_does_not_exist"

--- a/tests/test_UnitTestGenerator.py
+++ b/tests/test_UnitTestGenerator.py
@@ -9,7 +9,8 @@ from unittest.mock import patch, mock_open
 
 
 class TestUnitTestGenerator:
-    def test_end_to_end1(self):
+    @staticmethod
+    def test_end_to_end1():
         # Test model definitions
         GPT4_TURBO = "gpt-4-turbo-2024-04-09"
         GPT35_TURBO = "gpt-3.5-turbo-0125"
@@ -65,7 +66,8 @@ class TestUnitTestGenerator:
         with open(TEST_FILE, "w") as f:
             f.write(original_file_contents)
 
-    def test_end_to_end2(self):
+    @staticmethod
+    def test_end_to_end2():
         # Test model definitions
         GPT4_TURBO = "gpt-4-turbo-2024-04-09"
         GPT35_TURBO = "gpt-3.5-turbo-0125"
@@ -123,7 +125,8 @@ class TestUnitTestGenerator:
         with open(TEST_FILE, "w") as f:
             f.write(original_file_contents)
 
-    def test_get_included_files_mixed_paths(self):
+    @staticmethod
+    def test_get_included_files_mixed_paths():
         with patch("builtins.open", mock_open(read_data="file content")) as mock_file:
             mock_file.side_effect = [
                 IOError("File not found"),
@@ -136,7 +139,8 @@ class TestUnitTestGenerator:
                 == "file_path: `valid_file2.txt`\ncontent:\n```\nfile content\n```"
             )
 
-    def test_get_included_files_valid_paths(self):
+    @staticmethod
+    def test_get_included_files_valid_paths():
         with patch("builtins.open", mock_open(read_data="file content")):
             included_files = ["file1.txt", "file2.txt"]
             result = UnitTestGenerator.get_included_files(included_files)
@@ -147,13 +151,15 @@ class TestUnitTestGenerator:
 
 
 class TestExtractErrorMessage:
-    def test_extract_single_match(self):
+    @staticmethod
+    def test_extract_single_match():
         fail_message = "=== FAILURES ===\\nError occurred here\\n=== END ==="
         expected = "\\nError occurred here\\n"
         result = extract_error_message_python(fail_message)
         assert result == expected, f"Expected '{expected}', got '{result}'"
 
-    def test_extract_bad_match(self):
+    @staticmethod
+    def test_extract_bad_match():
         fail_message = 33
         expected = ""
         result = extract_error_message_python(fail_message)

--- a/tests/test_load_yaml.py
+++ b/tests/test_load_yaml.py
@@ -9,12 +9,14 @@ from coverage_ai.utils import load_yaml
 
 class TestLoadYaml:
     #  Tests that load_yaml loads a valid YAML string
-    def test_load_valid_yaml(self):
+    @staticmethod
+    def test_load_valid_yaml():
         yaml_str = "name: John Smith\nage: 35"
         expected_output = {"name": "John Smith", "age": 35}
         assert load_yaml(yaml_str) == expected_output
 
-    def test_load_invalid_yaml1(self):
+    @staticmethod
+    def test_load_invalid_yaml1():
         yaml_str = '''\
 PR Analysis:
   Main theme: Enhancing the `/describe` command prompt by adding title and description
@@ -65,7 +67,8 @@ PR Feedback:
             == expected_output
         )
 
-    def test_load_invalid_yaml2(self):
+    @staticmethod
+    def test_load_invalid_yaml2():
         yaml_str = """\
 - relevant file: src/app.py:
   suggestion content: The print statement is outside inside the if __name__ ==: \

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -57,9 +57,8 @@ class TestMain:
         parse_args = lambda: args  # Mocking parse_args function
         mock_isfile.return_value = False  # Simulate source file not found
 
-        with patch("coverage_ai.main.parse_args", parse_args):
-            with pytest.raises(FileNotFoundError) as exc_info:
-                main()
+        with patch("coverage_ai.main.parse_args", parse_args), pytest.raises(FileNotFoundError) as exc_info:
+            main()
 
         assert (
             str(exc_info.value) == f"Source file not found at {args.source_file_path}"
@@ -90,8 +89,7 @@ class TestMain:
         mock_isfile.side_effect = [True, False]
         mock_exists.return_value = True
 
-        with patch("coverage_ai.main.parse_args", parse_args):
-            with pytest.raises(FileNotFoundError) as exc_info:
-                main()
+        with patch("coverage_ai.main.parse_args", parse_args), pytest.raises(FileNotFoundError) as exc_info:
+            main()
 
         assert str(exc_info.value) == f"Test file not found at {args.test_file_path}"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,7 +6,8 @@ from coverage_ai.main import parse_args, main
 
 
 class TestMain:
-    def test_parse_args(self):
+    @staticmethod
+    def test_parse_args():
         with patch(
             "sys.argv",
             [

--- a/tests_integration/increase_coverage.py
+++ b/tests_integration/increase_coverage.py
@@ -9,7 +9,6 @@ from coverage_ai.CoverageAi import CoverageAi
 # List of source/test files to iterate over:
 SOURCE_TEST_FILE_LIST = [
     ["coverage_ai/AICaller.py", "tests/test_AICaller.py"],
-    # ["coverage_ai/CoverageAi.py",               "tests/test_CoverageAi.py"],
     ["coverage_ai/CoverageProcessor.py", "tests/test_CoverageProcessor.py"],
     ["coverage_ai/FilePreprocessor.py", "tests/test_FilePreprocessor.py"],
     ["coverage_ai/PromptBuilder.py", "tests/test_PromptBuilder.py"],
@@ -18,8 +17,6 @@ SOURCE_TEST_FILE_LIST = [
     ["coverage_ai/UnitTestGenerator.py", "tests/test_UnitTestGenerator.py"],
     ["coverage_ai/version.py", "tests/test_version.py"],
     ["coverage_ai/utils.py", "tests/test_load_yaml.py"],
-    # ["coverage_ai/settings/config_loader.py", "tests/test_.py"],
-    # ["coverage_ai/CustomLogger.py",             ""],
 ]
 
 


### PR DESCRIPTION
### **User description**
**Description**

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [*] Yes, I signed my commits.
 

<!--
Thank you for contributing to KhulnaSoft! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Introduced `total_input_token_count` and `total_output_token_count` attributes to track token usage in AI model interactions.
- Replaced `raise AssertionError` with `assert` for more concise error handling.
- Added comprehensive docstrings to methods `initial_test_suite_analysis`, `generate_tests`, `validate_test`, and `extract_error_message_python`.
- Updated methods to increment token counts after AI model calls to ensure accurate tracking.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UnitTestGenerator.py</strong><dd><code>Enhance token tracking and add detailed docstrings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

coverage_ai/UnitTestGenerator.py

<li>Added attributes <code>total_input_token_count</code> and <code>total_output_token_count</code> <br>to track token usage.<br> <li> Replaced <code>raise AssertionError</code> with <code>assert</code> for cleaner error handling.<br> <li> Added detailed docstrings to several methods for better documentation.<br> <li> Updated methods to increment token counts after AI model calls.<br>


</details>


  </td>
  <td><a href="https://github.com/khulnasoft/coverage-ai/pull/34/files#diff-d3999e4a158e834269e8bd4e7598195e87f9731a327b413614a6b64dae93e284">+81/-7</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

